### PR TITLE
Fix extra RNG calls when viewing info screen

### DIFF
--- a/Plugins/Tectonic Battle/Battle/Actions/Battle_Action_AttacksPriority.rb
+++ b/Plugins/Tectonic Battle/Battle/Actions/Battle_Action_AttacksPriority.rb
@@ -151,15 +151,18 @@ class PokeBattle_Battle
     #=============================================================================
     # Turn order calculation (priority)
     #=============================================================================
-    def pbCalculatePriority(fullCalc = false, indexArray = nil)
+    def pbCalculatePriority(fullCalc = false, indexArray = nil, randomizeOrder = true)
         needRearranging = false
         if fullCalc
             @priorityTrickRoom = @field.effectActive?(:TrickRoom)
             # Recalculate everything from scratch
             randomOrder = Array.new(maxBattlerIndex + 1) { |i| i }
-            (randomOrder.length - 1).times do |i| # Can't use shuffle! here
-                r = i + pbRandom(randomOrder.length - i)
-                randomOrder[i], randomOrder[r] = randomOrder[r], randomOrder[i]
+            # don't do extra random calls if recalculating for info screen, to ensure cable club sync
+            if randomizeOrder
+                (randomOrder.length - 1).times do |i| # Can't use shuffle! here
+                    r = i + pbRandom(randomOrder.length - i)
+                    randomOrder[i], randomOrder[r] = randomOrder[r], randomOrder[i]
+                end
             end
             @priority.clear
             for i in 0..maxBattlerIndex
@@ -289,7 +292,8 @@ class PokeBattle_Battle
     # are expected to move this turn, accounting for only speed and trick room
     # Pokemon with speed ties are assigned the same number
     def pbTurnOrderDisplayed
-        pbCalculatePriority(true)
+        # don't do extra random calls if recalculating for info screen, to ensure cable club sync
+        pbCalculatePriority(true,nil,false)
         
         speedHash = {}
 


### PR DESCRIPTION
Other calls to pbCalculatePriority should be unaffected