### PR TITLE
Change Time Skip to activate once every other turn

### DIFF
--- a/PBS/abilities_new.txt
+++ b/PBS/abilities_new.txt
@@ -2123,7 +2123,7 @@ Description = Its attacks have priority, deal 25% less damage and become special
 #-------------------------------
 [TIMESKIP]
 Name = Time Skip
-Description = Between each turn there's another turn where no one moves.
+Description = Every two turns, another turn happens where no one moves.
 #-------------------------------
 [TOILANDTROUBLE]
 Name = Toil and Trouble

--- a/Plugins/Tectonic Battle/Battle/Battle_StartAndEnd.rb
+++ b/Plugins/Tectonic Battle/Battle/Battle_StartAndEnd.rb
@@ -510,11 +510,25 @@ class PokeBattle_Battle
             @turnCount += 1
 
             # Extra fake turn
-            stretcher = pbCheckGlobalAbility(:TIMESKIP)
-            if stretcher
-                pbShowAbilitySplash(stretcher, :TIMESKIP)
-                pbDisplay(_INTL("Time is dancing to {1}'s tune! This turn is being skipped!", stretcher.pbThis))
-                pbHideAbilitySplash(stretcher)
+            stretchers = []
+            eachBattler { |b| stretchers.append(b) if b.hasActiveAbility?(:TIMESKIP) }
+
+            timeStretcher = nil
+            if stretchers.length > 0
+                stretchers.each do |stretcher|
+                    unless stretcher.effectActive?(:NoTimeSkip)
+                        timeStretcher = stretcher
+                        stretcher.applyEffect(:NoTimeSkip)
+                    else
+                        stretcher.disableEffect(:NoTimeSkip)
+                    end
+                end
+            end
+
+            unless timeStretcher.nil?
+                pbShowAbilitySplash(timeStretcher, :TIMESKIP)
+                pbDisplay(_INTL("Time is dancing to {1}'s tune! This turn is being skipped!", timeStretcher.pbThis))
+                pbHideAbilitySplash(timeStretcher)
                 # Start of round phase
                 PBDebug.logonerr { pbStartOfRoundPhase }
                 break if @decision > 0
@@ -523,6 +537,7 @@ class PokeBattle_Battle
                 break if @decision > 0
                 @turnCount += 1
             end
+
         end
         pbEndOfBattle
     end

--- a/Plugins/Tectonic Battle/Effects/EffectDefinitions/BattlerEffects.rb
+++ b/Plugins/Tectonic Battle/Effects/EffectDefinitions/BattlerEffects.rb
@@ -2392,3 +2392,8 @@ GameData::BattleEffect.register_effect(:Battler, {
         battle.pbDisplay(_INTL("{1} is no longer bound in tangling vines.", battler.pbThis))
     end,
 })
+
+GameData::BattleEffect.register_effect(:Battler, {
+    :id => :NoTimeSkip,
+    :real_name => "No Time Skip",
+})


### PR DESCRIPTION
The ability Time Skip now activates every two turns, starting at the first turn out.

Having two Celebis on the field brought out at alternating turns will ensure a Time Skip every turn, but not otherwise.