### PR TITLE
Add "Sticky Item" flag to Pokemon data

### DIFF
--- a/PBS/encounters.txt
+++ b/PBS/encounters.txt
@@ -318,10 +318,10 @@ Special,20
 [081] # East Tunnel
 Puddle,20,20
     20,CARVANHA,18,20
+    20,MANTYKE,18,20
     20,MAREANIE,18,20
     20,REMORAID,18,20
     20,TENTACOOL,18,20
-    20,MANTYKE,18,20
 #-------------------------------
 [085] # Worried Man's House
 Special,20

--- a/PBS/pokemon.txt
+++ b/PBS/pokemon.txt
@@ -10378,6 +10378,7 @@ Kind = Sea Basin
 Pokedex = Kyogre is said to be the personification of the sea itself. Legends tell of its many clashes against Groudon, as each sought to gain the power of nature.
 Generation = 3
 Flags = Legendary
+StickyItems = BLUEORB
 #-------------------------------
 [GROUDON]
 Name = Groudon
@@ -10401,6 +10402,7 @@ Kind = Continent
 Pokedex = Groudon is said to be the personification of the land itself. Legends tell of its many clashes against Kyogre, as each sought to gain the power of nature.
 Generation = 3
 Flags = Legendary
+StickyItems = REDORB
 #-------------------------------
 [RAYQUAZA]
 Name = Rayquaza
@@ -11988,6 +11990,7 @@ Pokedex = This Pokémon is said to live in a world on the reverse side of ours, 
 FormName = Altered
 Generation = 4
 Flags = Legendary
+StickyItems = GRISEOUSORB
 #-------------------------------
 [CRESSELIA]
 Name = Cresselia
@@ -12117,6 +12120,7 @@ Pokedex = It is told in mythology that this Pokémon was born before the univers
 FormName = Arceus
 Generation = 4
 Flags = Legendary
+StickyItems = PRISMATICPLATE
 #-------------------------------
 [SNIVY]
 Name = Snivy
@@ -15815,6 +15819,7 @@ Pokedex = This Pokémon existed 300 million years ago. Team Plasma altered it an
 FormName = Genesect
 Generation = 5
 Flags = Legendary
+StickyItems = BURNDRIVE,CHILLDRIVE,DOUSEDRIVE,SHOCKDRIVE
 #-------------------------------
 [VICTINI]
 Name = Victini
@@ -16980,6 +16985,7 @@ Kind = Jewel
 Pokedex = It can instantly create many diamonds by compressing the carbon in the air between its hands.
 Generation = 6
 Flags = Legendary
+StickyItems = CRYSTALCALIBURN
 #-------------------------------
 [GOOMY]
 Name = Goomy
@@ -18499,6 +18505,7 @@ Pokedex = This is its form once it has awakened and evolved. Freed from its heav
 FormName = Type: Normal
 Generation = 7
 Flags = Legendary
+StickyItems = MEMORYSET
 #-------------------------------
 [MINIOR]
 Name = Minior

--- a/Plugins/Tectonic Game Data/Compiled Data/Item.rb
+++ b/Plugins/Tectonic Game Data/Compiled Data/Item.rb
@@ -298,16 +298,10 @@ module GameData
       end
   
       def unlosable?(species, ability)
-        combos = {
-           :ARCEUS   => [:PRISMATICPLATE],
-           :SILVALLY => [:MEMORYSET],
-           :GIRATINA => [:GRISEOUSORB],
-           :GENESECT => [:BURNDRIVE, :CHILLDRIVE, :DOUSEDRIVE, :SHOCKDRIVE],
-           :KYOGRE   => [:BLUEORB],
-           :GROUDON  => [:REDORB],
-           :DIANCIE  => [:CRYSTALCALIBURN]
-        }
-        return combos[species] && combos[species].include?(@id)
+        base_form_data = GameData::Species.get_species_form(species, 0)
+        return false if base_form_data.nil?
+        sticky_items = base_form_data.sticky_items
+        return sticky_items.include?(@id)
       end
 
       def legal?(isTrainer = false)

--- a/Plugins/Tectonic Game Data/Compiled Data/Species.rb
+++ b/Plugins/Tectonic Game Data/Compiled Data/Species.rb
@@ -44,6 +44,7 @@ module GameData
         attr_accessor :earliest_available
         attr_reader :flags
         attr_reader :formalizer
+        attr_reader :sticky_items
 
         DATA = {}
         DATA_FILENAME = "species.dat"
@@ -121,6 +122,7 @@ module GameData
                 ret["GrowthRate"]   = [0, "e", :GrowthRate]
                 ret["GenderRate"]   = [0, "e", :GenderRatio]
                 ret["Evolutions"]   = [0, "*ses", nil, :Evolution, nil]
+                ret["StickyItems"]   = [0, "*e", :Item]
             end
             return ret
         end
@@ -190,6 +192,7 @@ module GameData
             @defined_in_extension  = hash[:defined_in_extension]  || false
             @flags                 = hash[:flags]                 || []
             @formalizer            = hash[:formalizer]            || []
+            @sticky_items          = hash[:sticky_items]          || []
 
             legalityChecks
         end
@@ -763,6 +766,7 @@ module Compiler
                       :generation            => contents["Generation"],
                       :flags                 => contents["Flags"],
                       :formalizer            => contents["Formalizer"],
+                      :sticky_items          => contents["StickyItems"],
                       :notes                 => contents["Notes"],
                       :tribes                => contents["Tribes"],
                       :defined_in_extension  => !baseFile,
@@ -1188,6 +1192,7 @@ module Compiler
         f.write(format("WildItemCommon = %s\r\n", species.wild_item_common)) if species.wild_item_common
         f.write(format("WildItemUncommon = %s\r\n", species.wild_item_uncommon)) if species.wild_item_uncommon
         f.write(format("WildItemRare = %s\r\n", species.wild_item_rare)) if species.wild_item_rare
+        f.write(format("StickyItems = %s\r\n", species.sticky_items.join(","))) if species.sticky_items.length > 0
         if species.evolutions.any? { |evo| !evo[3] }
             f.write("Evolutions = ")
             need_comma = false


### PR DESCRIPTION
Defines items which that Pokemon cannot lose, instead of the hardcoded unlosable function