### PR TITLE
Add turn tracker for Noel's curse to Info screen

### DIFF
--- a/Plugins/Tectonic Battle/AI/Trainers AI/Curses/ChronicFreeze.rb
+++ b/Plugins/Tectonic Battle/AI/Trainers AI/Curses/ChronicFreeze.rb
@@ -16,6 +16,7 @@ PokeBattle_Battle::BeginningOfTurnCurseEffect.add(:CURSE_NO_MOVING_CYCLICAL,
                 battle.pbAnimation(:SHEERCOLD, b, b)
                 b.applyEffect(:IceSculpture)
             end
+            battle.sides[0].applyEffect(:IceSculptureTurns, 4)
         elsif battle.turnCount % 4 == 3
             battle.pbDisplay(_INTL("The freeze will arrive next turn."))
         end

--- a/Plugins/Tectonic Battle/Effects/EffectDefinitions/SideEffects.rb
+++ b/Plugins/Tectonic Battle/Effects/EffectDefinitions/SideEffects.rb
@@ -875,3 +875,10 @@ GameData::BattleEffect.register_effect(:Side, {
         battle.pbDisplay(_INTL("{1} is no longer blessed by the Wishing Well.", teamName))
     end,
 })
+
+GameData::BattleEffect.register_effect(:Side, {
+    :id => :IceSculptureTurns,
+    :real_name => "Turns Until Freeze",
+    :type => :Integer,
+    :ticks_down => true
+})


### PR DESCRIPTION
"Turns until freeze" isn't the *most* clear name, but space is limited, and the 1-turn warning does refer to it as "the freeze"