### PR TITLE
Make Trick Room properly only set for 4 turns

### DIFF
--- a/Plugins/Tectonic Battle/Battle/PokeBattle_Rooms.rb
+++ b/Plugins/Tectonic Battle/Battle/PokeBattle_Rooms.rb
@@ -1,7 +1,8 @@
 
 class PokeBattle_Battle
-    def pbStartRoom(roomEffect, user, ability = nil, aiCheck = false, duration: nil)
-        duration = duration || (ability ? 4 : 8)
+    # short: shortened duration due to ability set or trick room exception
+    def pbStartRoom(roomEffect, user, short = nil, aiCheck = false, duration: nil)
+        duration = duration || (short ? 4 : 8)
         duration = user.getRoomDuration(duration, aiCheck: aiCheck)
         effectName = GameData::BattleEffect.get(roomEffect).name
         

--- a/Plugins/Tectonic Battle/Move Codes/Field affecting/Move_Codes_RoomSetting.rb
+++ b/Plugins/Tectonic Battle/Move Codes/Field affecting/Move_Codes_RoomSetting.rb
@@ -94,5 +94,6 @@ class PokeBattle_Move_StartSwapSpeedOrder4 < PokeBattle_RoomMove
     def initialize(battle, move)
         super
         @roomEffect = :TrickRoom
+        @short = true
     end
 end

--- a/Plugins/Tectonic Battle/Move Codes/ParentMoveCodes.rb
+++ b/Plugins/Tectonic Battle/Move Codes/ParentMoveCodes.rb
@@ -1034,14 +1034,15 @@ class PokeBattle_RoomMove < PokeBattle_Move
         super
         @roomEffect = nil
         @duration = nil
+        @short = false
     end
 
     def pbEffectGeneral(user)
-        @battle.pbStartRoom(@roomEffect, user)
+        @battle.pbStartRoom(@roomEffect, user, @short)
     end
 
     def getEffectScore(user, _target)
-        return @battle.pbStartRoom(@roomEffect, user, nil, true)
+        return @battle.pbStartRoom(@roomEffect, user, @short, true)
     end
 end
 


### PR DESCRIPTION
It's not currently clear whether Trick Room should be set for 4 or 8 turns - 8 turns is consistent with other Room setting moves and the code structure, but 4 turns is what the description says and might be more balanced. This PR can be merged if it's decided that 4 turns is correct, and has modified the structure to make the 4 turn duration less of a weird exception.