### PR TITLE
Delay all stat drop triggers until after a batch of multiple drops

### DIFF
--- a/Plugins/Tectonic Battle/Abilities/Ability Event Handlers/Other Triggers/AbilitiesOnStatLoss.rb
+++ b/Plugins/Tectonic Battle/Abilities/Ability Event Handlers/Other Triggers/AbilitiesOnStatLoss.rb
@@ -1,26 +1,26 @@
 BattleHandlers::AbilityOnStatLoss.add(:COMPETITIVE,
-  proc { |ability, battler, _stat, user|
+  proc { |ability, battler, user|
       next unless user&.opposes?(battler)
       battler.tryRaiseStat(:SPECIAL_ATTACK, battler, ability: ability, increment: 4)
   }
 )
 
 BattleHandlers::AbilityOnStatLoss.add(:DEFIANT,
-  proc { |ability, battler, _stat, user|
+  proc { |ability, battler, user|
       next unless user&.opposes?(battler)
       battler.tryRaiseStat(:ATTACK, battler, ability: ability, increment: 4)
   }
 )
 
 BattleHandlers::AbilityOnStatLoss.add(:BELLIGERENT,
-  proc { |ability, battler, _stat, user|
+  proc { |ability, battler, user|
       next unless user&.opposes?(battler)
       battler.pbRaiseMultipleStatSteps([:ATTACK, 3, :SPECIAL_ATTACK, 3], battler, ability: ability)
   }
 )
 
 BattleHandlers::AbilityOnStatLoss.add(:IMPERIOUS,
-  proc { |ability, battler, _stat, user|
+  proc { |ability, battler, user|
       next unless user&.opposes?(battler)
       battler.tryRaiseStat(:SPEED, battler, ability: ability, increment: 4)
   }

--- a/Plugins/Tectonic Battle/BattleHandlers.rb
+++ b/Plugins/Tectonic Battle/BattleHandlers.rb
@@ -275,8 +275,8 @@ module BattleHandlers
         AbilityOnEnemyStatGain.trigger(ability, battler, stat, increment, user, battle, benefactor)
     end
 
-    def self.triggerAbilityOnStatLoss(ability, battler, stat, user)
-        AbilityOnStatLoss.trigger(ability, battler, stat, user)
+    def self.triggerAbilityOnStatLoss(ability, battler, user)
+        AbilityOnStatLoss.trigger(ability, battler, user)
     end
 
     #=============================================================================

--- a/Plugins/Tectonic Battle/Battler/Battler_StatStages.rb
+++ b/Plugins/Tectonic Battle/Battler/Battler_StatStages.rb
@@ -746,7 +746,7 @@ class PokeBattle_Battler
             showStatChangeMessage(statIDList, increment, lowering: true)
         end
 
-        triggersOnStatLoss(user, move)
+        triggersOnStatLoss(user: user, move: move)
 
         @battle.pbHideAbilitySplash(user) if ability
         return loweredAnySteps

--- a/Plugins/Tectonic Battle/Battler/Battler_StatStages.rb
+++ b/Plugins/Tectonic Battle/Battler/Battler_StatStages.rb
@@ -430,8 +430,10 @@ class PokeBattle_Battler
             @battle.pbHideAbilitySplash(user) if showMessages
         end
 
-        # do not trigger item effects if dropping multiple stats - the multiple stat function will do that afterwards
-        triggersOnStatLoss(stat, increment, user: user, triggerItems: !multiple)
+        # do not trigger effects if dropping multiple stats - the multiple stat function will do that afterwards
+        if !multiple
+            triggersOnStatLoss(user: user)
+        end
 
         return increment
     end
@@ -493,7 +495,7 @@ class PokeBattle_Battler
         end
         @battle.pbDisplay(lowerMessage)
 
-        triggersOnStatLoss(stat, increment, user: user)
+        triggersOnStatLoss(user: user)
 
         return true
     end
@@ -553,24 +555,21 @@ class PokeBattle_Battler
             @battle.pbDisplay(_INTL("{1} minimized its {2}!", pbThis, statName))
             @battle.pbHideAbilitySplash(user) if ability
 
-            triggersOnStatLoss(stat, increment, user: user, move: move)
+            triggersOnStatLoss(user: user, move: move)
         end
     end
 
-    def triggersOnStatLoss(stat, increment, user: nil, move: nil, triggerItems: true)
+    def triggersOnStatLoss(user: nil, move: nil)
         playStatStepsTutorial unless $PokemonGlobal.statStepsTutorialized
 
         applyEffect(:StatsDropped)
 
         # Trigger abilities upon stat loss
         eachActiveAbility do |ability|
-            BattleHandlers.triggerAbilityOnStatLoss(ability, self, stat, user)
+            BattleHandlers.triggerAbilityOnStatLoss(ability, self, user)
         end
 
-        triggersItemsOnStatLoss(user, move) if triggerItems
-    end
-
-    def triggersItemsOnStatLoss(user, move)
+        # Trigger items upon stat loss
         eachActiveItem do |item|
             BattleHandlers.triggerItemOnStatLoss(item, self, user, move, [], @battle)
         end
@@ -749,7 +748,7 @@ class PokeBattle_Battler
             showStatChangeMessage(statIDList, increment, lowering: true)
         end
 
-        triggersItemsOnStatLoss(user, move)
+        triggersOnStatLoss(user, move)
 
         @battle.pbHideAbilitySplash(user) if ability
         return loweredAnySteps

--- a/Plugins/Tectonic Battle/Battler/Battler_StatStages.rb
+++ b/Plugins/Tectonic Battle/Battler/Battler_StatStages.rb
@@ -431,9 +431,7 @@ class PokeBattle_Battler
         end
 
         # do not trigger effects if dropping multiple stats - the multiple stat function will do that afterwards
-        if !multiple
-            triggersOnStatLoss(user: user)
-        end
+        triggersOnStatLoss(user: user) unless multiple
 
         return increment
     end


### PR DESCRIPTION
Effectively nerfs Defiant etc

This is not yet tested in game, that's persnickety and I'm tired, if someone else could pull this branch and do so that would be appreciated.

This removes currently-unused functionality to check the specific stat being dropped. A more future-proof approach might be to allow the handler to accept an array of multiple dropped stats for hypothetical future abilities to test against.